### PR TITLE
fix: handle response data correctly in getPackage method

### DIFF
--- a/src/Headless.php
+++ b/src/Headless.php
@@ -240,7 +240,7 @@ class Headless extends TebexAPI {
     public static function getPackage(int $packageId) : Package
     {
         $packageDataJson = self::_request("GET", "packages/" . $packageId);
-        return new Package($packageDataJson);
+        return new Package($packageDataJson["data"]);
     }
 
     /**


### PR DESCRIPTION
# Fix: Handle response data correctly in `getPackage` method

## Description

This pull request fixes an issue with the `getPackage` method, where it was incorrectly initializing the `Package` object with the entire JSON response. The method now correctly uses the `data` field from the response JSON.

### Testing

1. Call `getPackage` with a valid `packageId`.
2. Confirm the returned `Package` object is properly initialized with the `data` field from the API response.

### Checklist

- [x] Code change fixes the issue.
- [x] Tests have been conducted to verify the fix.

### Related Issues

- None reported.
